### PR TITLE
Update inference runners

### DIFF
--- a/core/embeddings/base.py
+++ b/core/embeddings/base.py
@@ -1,26 +1,15 @@
-import json
-import os
 from abc import ABC, abstractmethod
 from collections import deque
-from pathlib import Path
 
 
 class BaseEmbeddingsModel(ABC):
 
     def __init__(
         self,
-        model_name: str,
-        model_path: str | os.PathLike,
         normalize: bool
     ):
-        self.model_name = model_name
-        self.model_path = Path(model_path)
         self.normalize = normalize
-
         self._infer_times = deque(maxlen=100)
-
-    def __repr__(self) -> str:
-        return f"{self.model_name} [{self.model_path}]"
     
     @property
     def last_infer_time(self) -> float | None:
@@ -41,12 +30,3 @@ class BaseEmbeddingsModel(ABC):
     @abstractmethod
     def generate(self, text: str) -> list[float]:
         ...
-
-    @classmethod
-    def from_config(cls, config: dict | str | os.PathLike) -> "BaseEmbeddingsModel":
-        if not isinstance(config, dict):
-            with open(config) as f:
-                model_config = json.load(f)
-        else:
-            model_config = config
-        return cls(**model_config)

--- a/core/speech_to_text/__init__.py
+++ b/core/speech_to_text/__init__.py
@@ -32,7 +32,7 @@ def moonshine_factory(
     model_type, model_size, quant_type = model_name.split("-")
     if model_type == "onnx":
         return MoonshineOnnx(model_size=model_size, quant_type=quant_type, rate=sampling_rate, n_threads=n_threads)
-    return MoonshineSynap(model_size=model_size, quant_type=quant_type, rate=sampling_rate)
+    return MoonshineSynap(model_size=model_size, quant_type=quant_type, rate=sampling_rate, n_threads=n_threads)
 
 
 class SpeechToTextAgent:

--- a/core/speech_to_text/moonshine.py
+++ b/core/speech_to_text/moonshine.py
@@ -25,7 +25,8 @@ class MoonshineSynap(BaseSpeechToTextModel):
         model_size: Literal["base", "tiny"] = "tiny",
         quant_type: Literal["float", "quantized"] = "float",
         rate: int = 16_000,
-        max_tok_per_s: int | None = None
+        max_tok_per_s: int | None = None,
+        n_threads: int | None = None
     ):
         super().__init__(
             hf_repo,
@@ -36,6 +37,7 @@ class MoonshineSynap(BaseSpeechToTextModel):
         self.encoder_onnx = OnnxInferenceRunner.from_hf(
             hf_repo=hf_repo,
             filename=f"onnx/merged/{model_size}/float/encoder_model.onnx",
+            n_threads=n_threads
         )
         self.encoder = SynapInferenceRunner.from_uri(
             url=f"https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/moonshine_{model_size}_{self.quant_type}_encoder.synap",

--- a/initialize.py
+++ b/initialize.py
@@ -24,8 +24,8 @@ if __name__ == "__main__":
         filename=MODELS_DIR / f"gguf/all-MiniLM-L6-v2-Q8_0.gguf"
     )
     download_from_url(
-        url="https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/all-MiniLM-L6-v2.synap",
-        filename=MODELS_DIR / f"synap/all-MiniLM-L6-v2.synap"
+        url="https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/all-MiniLM-L6-v2-quantized.synap",
+        filename=MODELS_DIR / f"synap/all-MiniLM-L6-v2/model_quantized.synap"
     )
     # download Moonshine models
     download_from_hf(

--- a/profile/moonshine.py
+++ b/profile/moonshine.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
             )
         elif model_type == "synap":
             models[model_name] = MoonshineSynap(
-                model_size=model_size, quant_type=model_quant
+                model_size=model_size, quant_type=model_quant, n_threads=args.threads
             )
             if not isinstance(max_inp_len, int) or models[model_name].max_inp_len < max_inp_len:
                 max_inp_len = models[model_name].max_inp_len


### PR DESCRIPTION
> [!WARNING]
> The `--cpu-only` flag in [demos/](demos/), [profile/](profile/) and [assistant.py](assistant.py) has been deprecated and replaced with explicit model name argument.

Update inference runners:
* Add threading to `MoonshineSynap`
* Update MiniLM runners to match new runner API