### PR TITLE
Overhaul `assistant.py`

### DIFF
--- a/core/speech_to_text/__init__.py
+++ b/core/speech_to_text/__init__.py
@@ -56,6 +56,7 @@ class SpeechToTextAgent:
         model_name: str,
         handler: Callable[[str], Any],
         *,
+        audio_manager: AudioManager | None = None,
         eager_load: bool = True,
         n_threads: int | None = None,
         threshold: float = 0.3,
@@ -77,7 +78,7 @@ class SpeechToTextAgent:
             min_silence_duration_ms=min_silence_duration_ms,
         )
 
-        self.audio_manager = AudioManager()
+        self.audio_manager = audio_manager or AudioManager()
         self.caption_cache = []
         self.lookback_size = LOOKBACK_CHUNKS * CHUNK_SIZE
         self.speech = np.empty(0, dtype=np.float32)

--- a/core/speech_to_text/moonshine.py
+++ b/core/speech_to_text/moonshine.py
@@ -163,7 +163,7 @@ class MoonshineSynap(BaseSpeechToTextModel):
             tokens.append(next_token)
             if next_token == self.eos_token_id:
                 break
-        self._infer_stats["decoder_tokens"] = i
+        self._infer_stats["decoder_tokens"] = len(tokens)
         return np.array([tokens])
 
     def cleanup(self):
@@ -250,7 +250,7 @@ class MoonshineOnnx(BaseSpeechToTextModel):
                 break
 
         self._infer_stats["decoder_infer_time_ms"] = dec_time
-        self._infer_stats["decoder_tokens"] = i
+        self._infer_stats["decoder_tokens"] = len(gen_tokens)
         return gen_tokens
 
     def cleanup(self):

--- a/core/text_to_speech/__init__.py
+++ b/core/text_to_speech/__init__.py
@@ -6,6 +6,7 @@ import signal
 import subprocess
 import sys
 
+from ..utils.audio import AudioManager
 from ..utils.download import download_from_hf
 
 logger = logging.getLogger(__name__)
@@ -17,7 +18,7 @@ def handle_sigint(signum, frame):
 
 
 class TextToSpeechAgent:
-    def __init__(self, voice="en_US-lessac-low", output_dir="output"):
+    def __init__(self, voice="en_US-lessac-low", output_dir="output", audio_manager: AudioManager | None = None):
         # Voice must be in the format LOCALE-VOICENAME-STYLE, e.g. en_US-lessac-low
         parts = voice.split("-")
         if len(parts) != 3:
@@ -36,6 +37,7 @@ class TextToSpeechAgent:
         )
         self.output_dir = os.path.join(os.path.dirname(__file__), output_dir)
         os.makedirs(self.output_dir, exist_ok=True)
+        self.audio_manager = audio_manager or AudioManager()
 
     @staticmethod
     def file_checksum(content: str, hash_length: int = 16) -> str:

--- a/initialize.py
+++ b/initialize.py
@@ -18,23 +18,19 @@ if __name__ == "__main__":
     RESET: Final = "\033[0m"
 
     print(CYAN + "Downloading models..." + RESET)
-    # download MiniLM models
-    download_from_hf(
-        repo_id="second-state/All-MiniLM-L6-v2-Embedding-GGUF",
-        filename="all-MiniLM-L6-v2-Q8_0.gguf"
-    )
+    # download MiniLM
     download_from_url(
         url="https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/all-MiniLM-L6-v2-quantized.synap",
         filename=MODELS_DIR / f"synap/all-MiniLM-L6-v2/model_quantized.synap"
     )
-    # download Moonshine models
+    # download Moonshine
     download_from_hf(
         repo_id="UsefulSensors/moonshine",
-        filename=f"onnx/merged/tiny/float/encoder_model.onnx",
+        filename=f"onnx/merged/base/float/encoder_model.onnx",
     )
     download_from_hf(
         repo_id="UsefulSensors/moonshine",
-        filename=f"onnx/merged/tiny/float/decoder_model_merged.onnx",
+        filename=f"onnx/merged/base/float/decoder_model_merged.onnx",
     )
     download_from_hf(
         repo_id="UsefulSensors/moonshine-tiny", 
@@ -44,48 +40,7 @@ if __name__ == "__main__":
         repo_id="UsefulSensors/moonshine-tiny", 
         filename="tokenizer.json"
     )
-    download_from_url(
-        url="https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/moonshine_tiny_float_encoder.synap",
-        filename=MODELS_DIR / f"synap/moonshine/tiny/float/encoder.synap"
-    )
-    download_from_url(
-        url="https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/moonshine_tiny_float_decoder.synap",
-        filename=MODELS_DIR / f"synap/moonshine/tiny/float/decoder.synap"
-    )
-    download_from_url(
-        url="https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/moonshine_tiny_float_decoder_with_past.synap",
-        filename=MODELS_DIR / f"synap/moonshine/tiny/float/decoder_with_past.synap"
-    )
-    # download opus-mt-en-zh models
-    download_from_hf(
-        repo_id="Helsinki-NLP/opus-mt-en-zh",
-        filename="source.spm"
-    )
-    download_from_hf(
-        repo_id="Helsinki-NLP/opus-mt-en-zh",
-        filename="target.spm"
-    )
-    download_from_hf(
-        repo_id="Helsinki-NLP/opus-mt-en-zh",
-        filename="config.json"
-    )
-    download_from_hf(
-        repo_id="Helsinki-NLP/opus-mt-en-zh",
-        filename="vocab.json"
-    )
-    download_from_url(
-        url="https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/opus-mt-en-zh-float_encoder.synap",
-        filename=MODELS_DIR / f"synap/opus-mt/en-zh/float/encoder.synap"
-    )
-    download_from_url(
-        url="https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/opus-mt-en-zh-float_decoder.synap",
-        filename=MODELS_DIR / f"synap/opus-mt/en-zh/float/decoder.synap"
-    )
-    download_from_url(
-        url="https://github.com/spal-synaptics/on-device-assistant/releases/download/models-v1/opus-mt-en-zh-float_decoder_with_past.synap",
-        filename=MODELS_DIR / f"synap/opus-mt/en-zh/float/decoder_with_past.synap"
-    )
-    # download piper-tts models
+    # download piper-tts
     download_from_hf(
         repo_id="rhasspy/piper-voices",
         filename="en/en_US/lessac/low/en_US-lessac-low.onnx"
@@ -98,9 +53,9 @@ if __name__ == "__main__":
 
     print(CYAN + "Generating TTS cache..." + RESET)
     tts = TextToSpeechAgent()
-    for qa_file in DATA_DIR.glob("qa*.json"):
-        with open(qa_file, "r") as f:
-            answers = [pair["answer"] for pair in json.load(f)]
-            for answer in tqdm(answers, desc=qa_file.name):
-                tts.synthesize(answer)
+    qa_file = DATA_DIR / "qa_dishwasher.json"
+    with open(qa_file, "r") as f:
+        answers = [pair["answer"] for pair in json.load(f)]
+        for answer in tqdm(answers, desc=qa_file.name):
+            tts.synthesize(answer)
     print(GREEN + "TTS cache generation complete." + RESET)


### PR DESCRIPTION
### Make assistant modular

Supported modes:
* default: 
  * MiniLM -> NPU
  * Moonshine (base) -> CPU
  * PiperTTS -> CPU
* `--emb-model llama-quantized`:
  * MiniLM -> CPU
  * Moonshine (base) -> CPU
  * PiperTTS -> CPU
* `--stt-model synap-tiny-float`: MiniLM -> NPU
  * Moonshine (tiny, encoder) -> CPU
  * Moonshine (tiny, decoders) -> NPU
  * PiperTTS -> CPU
* more combinations (run `assistant.py --help`)

### Update `initialize.py`
* Only download models used in assistant's default mode:
  * MiniLM (NPU, `.synap`)
  * Moonshine-base (CPU, `.onnx`)
  * PiperTTS -> (CPU, `.onnx`)